### PR TITLE
Makes the ES subnet input an array so it can receive more than one subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "aws_elasticsearch_domain" "es" {
 
   vpc_options {
     security_group_ids = [ "${aws_security_group.elasticsearch.id}" ]
-    subnet_ids         = [ "${var.subnet_ids}" ]
+    subnet_ids = ["${split(",", var.subnet_ids)}"]
   }
 
   advanced_options {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "es_endpoint" {
+  value = "${aws_elasticsearch_domain.es.endpoint}"
+}


### PR DESCRIPTION
I was getting an error when trying to create the ES for more than one subnet. 

I changed the string for an array and it worked.
