### PR TITLE
Adds elasticsearch version param

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ variable "zone_id" {}
 
 
 // Optional
-variable "version" {
+variable "elasticsearch_version" {
   default = "5.5"
 }
 
@@ -90,7 +90,7 @@ resource "aws_security_group" "elasticsearch" {
 
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.name}"
-  elasticsearch_version = "${var.version}"
+  elasticsearch_version = "${var.elasticsearch_version}"
 
   cluster_config {
     instance_type = "${var.itype}"


### PR DESCRIPTION
Hi @egarbi ,

I had issues when creating the cluster and specifying the elasticsearch version. It's because version is reserved for modules. 

I'm using version 0.11.0 of Terraform, maybe it wasn't like that before...

In the end, all I did was to change the `version` for `elasticsearch_version` because the previous is reserved for module versions.