### PR TITLE
External Security Rules to allow extensibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,8 @@ resource "aws_security_group" "elasticsearch" {
 }
 
 resource "aws_security_group_rule" "secure_cidrs" {
+  count = "${length(var.ingress_allow_cidr_blocks) > 0 ? 1 : 0}"
+
   type        = "ingress"
   from_port   = 443
   to_port     = 443
@@ -28,6 +30,8 @@ resource "aws_security_group_rule" "secure_sgs" {
 }
 
 resource "aws_security_group_rule" "nonsecure_cidrs" {
+  count = "${length(var.ingress_allow_cidr_blocks) > 0 ? 1 : 0}"
+
   type        = "ingress"
   from_port   = 80
   to_port     = 80

--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,11 @@ resource "aws_security_group_rule" "secure_cidrs" {
 resource "aws_security_group_rule" "secure_sgs" {
   count = "${length(split(",", var.ingress_allow_security_groups))}"
 
-  type            = "ingress"
-  from_port       = 443
-  to_port         = 443
-  protocol        = "tcp"
-  source_security_group_id  = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
 
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }
@@ -40,15 +40,14 @@ resource "aws_security_group_rule" "nonsecure_cidrs" {
 resource "aws_security_group_rule" "nonsecure_sgs" {
   count = "${length(split(",", var.ingress_allow_security_groups))}"
 
-  type            = "ingress"
-  from_port       = 80
-  to_port         = 80
-  protocol        = "tcp"
-  source_security_group_id  = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
 
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }
-
 
 resource "aws_security_group_rule" "egress_all" {
   type        = "egress"
@@ -63,6 +62,7 @@ resource "aws_security_group_rule" "egress_all" {
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.name}"
   elasticsearch_version = "${var.elasticsearch_version}"
+
   encrypt_at_rest {
     enabled    = "${var.encryption_enabled}"
     kms_key_id = "${var.encryption_kms_key_id}"

--- a/main.tf
+++ b/main.tf
@@ -16,13 +16,13 @@ resource "aws_security_group_rule" "secure_cidrs" {
 }
 
 resource "aws_security_group_rule" "secure_sgs" {
-  count = "${length(split(",", var.ingress_allow_security_groups))}"
+  count = "${length(var.ingress_allow_security_groups)}"
 
   type                     = "ingress"
   from_port                = 443
   to_port                  = 443
   protocol                 = "tcp"
-  source_security_group_id = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+  source_security_group_id = "${element(var.ingress_allow_security_groups, count.index)}"
 
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }
@@ -38,13 +38,13 @@ resource "aws_security_group_rule" "nonsecure_cidrs" {
 }
 
 resource "aws_security_group_rule" "nonsecure_sgs" {
-  count = "${length(split(",", var.ingress_allow_security_groups))}"
+  count = "${length(var.ingress_allow_security_groups)}"
 
   type                     = "ingress"
   from_port                = 80
   to_port                  = 80
   protocol                 = "tcp"
-  source_security_group_id = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+  source_security_group_id = "${element(var.ingress_allow_security_groups, count.index)}"
 
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -29,30 +29,6 @@ resource "aws_security_group_rule" "secure_sgs" {
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }
 
-resource "aws_security_group_rule" "nonsecure_cidrs" {
-  count = "${length(var.ingress_allow_cidr_blocks) > 0 ? 1 : 0}"
-
-  type        = "ingress"
-  from_port   = 80
-  to_port     = 80
-  protocol    = "TCP"
-  cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
-
-  security_group_id = "${aws_security_group.elasticsearch.id}"
-}
-
-resource "aws_security_group_rule" "nonsecure_sgs" {
-  count = "${length(var.ingress_allow_security_groups)}"
-
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  source_security_group_id = "${element(var.ingress_allow_security_groups, count.index)}"
-
-  security_group_id = "${aws_security_group.elasticsearch.id}"
-}
-
 resource "aws_security_group_rule" "egress_all" {
   type        = "egress"
   from_port   = 0

--- a/main.tf
+++ b/main.tf
@@ -2,28 +2,62 @@ resource "aws_security_group" "elasticsearch" {
   name        = "${var.name}"
   description = "Security Group to allow traffic to ElasticSearch"
 
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
-  }
-
-  ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = ["${var.ingress_allow_security_groups}"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   vpc_id = "${var.vpc_id}"
+}
+
+resource "aws_security_group_rule" "secure_cidrs" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "TCP"
+  cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
+
+  security_group_id = "${aws_security_group.elasticsearch.id}"
+}
+
+resource "aws_security_group_rule" "secure_sgs" {
+  count = "${length(split(",", var.ingress_allow_security_groups))}"
+
+  type            = "ingress"
+  from_port       = 443
+  to_port         = 443
+  protocol        = "tcp"
+  source_security_group_id  = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+
+  security_group_id = "${aws_security_group.elasticsearch.id}"
+}
+
+resource "aws_security_group_rule" "nonsecure_cidrs" {
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "TCP"
+  cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
+
+  security_group_id = "${aws_security_group.elasticsearch.id}"
+}
+
+resource "aws_security_group_rule" "nonsecure_sgs" {
+  count = "${length(split(",", var.ingress_allow_security_groups))}"
+
+  type            = "ingress"
+  from_port       = 80
+  to_port         = 80
+  protocol        = "tcp"
+  source_security_group_id  = "${element(split(",",var.ingress_allow_security_groups), count.index)}"
+
+  security_group_id = "${aws_security_group.elasticsearch.id}"
+}
+
+
+resource "aws_security_group_rule" "egress_all" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.elasticsearch.id}"
 }
 
 resource "aws_elasticsearch_domain" "es" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,15 +3,15 @@ output "es_endpoint" {
 }
 
 output "es_arn" {
-  value ="${aws_elasticsearch_domain.es.arn}"
+  value = "${aws_elasticsearch_domain.es.arn}"
 }
 
 output "es_domain_id" {
-  value =  "${aws_elasticsearch_domain.es.domain_id}"
+  value = "${aws_elasticsearch_domain.es.domain_id}"
 }
 
 output "es_kibana_endpoint" {
-  value =  "${aws_elasticsearch_domain.es.kibana_endpoint}"
+  value = "${aws_elasticsearch_domain.es.kibana_endpoint}"
 }
 
 output "es_availability_zones_ids" {
@@ -20,4 +20,8 @@ output "es_availability_zones_ids" {
 
 output "es_vpc_ids" {
   value = "${aws_elasticsearch_domain.es.vpc_options.0.vpc_id}"
+}
+
+output "es_sg" {
+  value = "${aws_security_group.elasticsearch.id}"
 }


### PR DESCRIPTION
Hello Enrique,

Thank you very much for your work, it works wonderfully.

We needed access to port 80 in our deployment and as inline security group rules cannot be extended we have created this PR.

The changes made are:
- Extract rules  from Security Group
- Add Security Group ID to outputs

For more information on this issue see the Note at the top in
[Terraform Documentation](https://www.terraform.io/docs/providers/aws/r/security_group.html)

What do you think about this change?

Pau