### PR TITLE
make route53 zone id optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,8 @@ resource "aws_security_group_rule" "secure_cidrs" {
   from_port   = 443
   to_port     = 443
   protocol    = "TCP"
-  cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
+  #cidr_blocks = ["${var.ingress_allow_cidr_blocks}"]
+  cidr_blocks = var.ingress_allow_cidr_blocks
 
   security_group_id = "${aws_security_group.elasticsearch.id}"
 }
@@ -61,10 +62,11 @@ resource "aws_elasticsearch_domain" "es" {
 
   vpc_options {
     security_group_ids = ["${aws_security_group.elasticsearch.id}"]
-    subnet_ids         = ["${var.subnet_ids}"]
+    #subnet_ids         = ["${var.subnet_ids}"]
+    subnet_ids         = var.subnet_ids
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "${var.rest_action_multi_allow_explicit_index}"
     "indices.fielddata.cache.size"           = "${var.indices_fielddata_cache_size}"
     "indices.query.bool.max_clause_count"    = "${var.indices_query_bool_max_clause_count}"
@@ -80,7 +82,7 @@ resource "aws_elasticsearch_domain" "es" {
     automated_snapshot_start_hour = "${var.snapshot_start}"
   }
 
-  tags {
+  tags = {
     Domain = "${var.name}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ resource "aws_elasticsearch_domain" "es" {
 
 # Add ALB record on DNS
 resource "aws_route53_record" "main" {
+  count = "${length(var.zone_id) > 0 ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "${var.name}"
   type    = "CNAME"

--- a/variables.tf
+++ b/variables.tf
@@ -16,13 +16,13 @@ variable "vpc_id" {
   type        = "string"
 }
 
+// Optional
 variable "zone_id" {
-  default     = "Route 53 zone id where our "
-  description = ""
+  default     = ""
+  description = "Route 53 zone id where our Elastic Search Service EndPoints can be stored"
   type        = "string"
 }
 
-// Optional
 variable "access_policies" {
   default     = ""
   description = "IAM policy document specifying the access policies for the domain."

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
sometimes you don't want to use route53, for example when using microsoft active directory which has own local dns.
also update to support terraform v0.12  