### PR TITLE
Feature/add az count

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,40 +36,39 @@ CONFIG
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_policies | IAM policy document specifying the access policies for the domain. | string | `""` | no |
-| az_count | Number of Availability Zones for the domain to use with zone_awareness_enabled. Valid values: 2 or 3. | number | 2 | no |
-| create\_iam\_service\_linked\_role | Control the creation of the default service role, set it to false if you have already created it. | bool | true | no |
-| dedicated\_master | Indicates whether our cluster have dedicated master nodes enabled. | string | `"false"` | no |
-| elasticsearch\_version | Elastic Search Service cluster version number. | string | `"5.5"` | no |
-| encryption\_enabled | Enable encription in Elastic Search. | string | `"false"` | no |
-| encryption\_kms\_key\_id | Enable encription in Elastic Search. | string | `""` | no |
-| icount | Elastic Search Service cluster Ec2 instance number. | string | `"1"` | no |
-| indices\_fielddata\_cache\_size | Percentage of Java heap space allocated to field data. | string | `""` | no |
-| indices\_query\_bool\_max\_clause\_count | Maximum number of clauses allowed in a Lucene boolean query. | string | `"1024"` | no |
-| ingress\_allow\_cidr\_blocks | Specifies the ingress CIDR blocks allowed. | list | `<list>` | no |
-| ingress\_allow\_security\_groups | Specifies the ingress security groups allowed. | list | `<list>` | no |
-| itype | Elastic Search Service cluster Ec2 instance type. | string | `"m4.large.elasticsearch"` | no |
-| mcount | Elastic Search Service cluster dedicated master Ec2 instance number. | string | `"0"` | no |
-| mtype | Elastic Search Service cluster dedicated master Ec2 instance type. | string | `""` | no |
-| name | Elastic Search Service cluster name. | string | n/a | yes |
-| rest\_action\_multi\_allow\_explicit\_index | Specifies whether explicit references to indices are allowed inside the body of HTTP requests. | string | `"true"` | no |
-| snapshot\_start | Elastic Search Service maintenance/snapshot start time. | string | `"0"` | no |
-| subnet\_ids | List of VPC Subnet IDs for the Elastic Search Service EndPoints will be created. | list | n/a | yes |
-| volume\_size | Default size of the EBS volumes. | string | `"35"` | no |
-| volume\_type | Default type of the EBS volumes. | string | `"gp2"` | no |
-| vpc\_id | Vpc id where the Elastic Search Service cluster will be launched. | string | n/a | yes |
-| zone\_awareness | Indicates whether zone awareness is enabled. | string | `"false"` | no |
-| zone\_id | Route 53 zone id where the DNS record will be created. | string | `""` | no |
+| Name                                        | Description                                                                                       |  Type  |          Default           | Required |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------- | :----: | :------------------------: | :------: |
+| access\_policies                            | IAM policy document specifying the access policies for the domain.                                | string |            `""`            |    no    |
+| create\_iam\_service\_linked\_role          | Control the creation of the default service role, set it to false if you have already created it. |  bool  |            true            |    no    |
+| dedicated\_master                           | Indicates whether our cluster have dedicated master nodes enabled.                                | string |         `"false"`          |    no    |
+| elasticsearch\_version                      | Elastic Search Service cluster version number.                                                    | string |          `"5.5"`           |    no    |
+| encryption\_enabled                         | Enable encription in Elastic Search.                                                              | string |         `"false"`          |    no    |
+| encryption\_kms\_key\_id                    | Enable encription in Elastic Search.                                                              | string |            `""`            |    no    |
+| icount                                      | Elastic Search Service cluster Ec2 instance number.                                               | string |           `"1"`            |    no    |
+| indices\_fielddata\_cache\_size             | Percentage of Java heap space allocated to field data.                                            | string |            `""`            |    no    |
+| indices\_query\_bool\_max\_clause\_count    | Maximum number of clauses allowed in a Lucene boolean query.                                      | string |          `"1024"`          |    no    |
+| ingress\_allow\_cidr\_blocks                | Specifies the ingress CIDR blocks allowed.                                                        |  list  |          `<list>`          |    no    |
+| ingress\_allow\_security\_groups            | Specifies the ingress security groups allowed.                                                    |  list  |          `<list>`          |    no    |
+| itype                                       | Elastic Search Service cluster Ec2 instance type.                                                 | string | `"m4.large.elasticsearch"` |    no    |
+| mcount                                      | Elastic Search Service cluster dedicated master Ec2 instance number.                              | string |           `"0"`            |    no    |
+| mtype                                       | Elastic Search Service cluster dedicated master Ec2 instance type.                                | string |            `""`            |    no    |
+| name                                        | Elastic Search Service cluster name.                                                              | string |            n/a             |   yes    |
+| rest\_action\_multi\_allow\_explicit\_index | Specifies whether explicit references to indices are allowed inside the body of HTTP requests.    | string |          `"true"`          |    no    |
+| snapshot\_start                             | Elastic Search Service maintenance/snapshot start time.                                           | string |           `"0"`            |    no    |
+| subnet\_ids                                 | List of VPC Subnet IDs for the Elastic Search Service EndPoints will be created.                  |  list  |            n/a             |   yes    |
+| volume\_size                                | Default size of the EBS volumes.                                                                  | string |           `"35"`           |    no    |
+| volume\_type                                | Default type of the EBS volumes.                                                                  | string |          `"gp2"`           |    no    |
+| vpc\_id                                     | Vpc id where the Elastic Search Service cluster will be launched.                                 | string |            n/a             |   yes    |
+| zone\_awareness                             | Indicates whether zone awareness is enabled.                                                      | string |         `"false"`          |    no    |
+| zone\_id                                    | Route 53 zone id where the DNS record will be created.                                            | string |            `""`            |    no    |
 
 ## Outputs
-| Name | Description |
-|------|-------------|
-| es\_arn | Amazon Resource Name (ARN) of the domain |
+| Name                         | Description                                                                                                                |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| es\_arn                      | Amazon Resource Name (ARN) of the domain                                                                                   |
 | es\_availability\_zones\_ids | If the domain was created inside a VPC, the names of the availability zones the configured subnet_ids were created inside. |
-| es\_domain\_id | Unique identifier for the domain. |
-| es\_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests. |
-| es\_kibana\_endpoint | Domain-specific endpoint for kibana without https scheme. |
-| es\_sg | The SG id created to allow communication with ElasticSearch cluster. |
-| es\_vpc\_ids | The VPC ID if the domain was created inside a VPC. |
+| es\_domain\_id               | Unique identifier for the domain.                                                                                          |
+| es\_endpoint                 | Domain-specific endpoint used to submit index, search, and data upload requests.                                           |
+| es\_kibana\_endpoint         | Domain-specific endpoint for kibana without https scheme.                                                                  |
+| es\_sg                       | The SG id created to allow communication with ElasticSearch cluster.                                                       |
+| es\_vpc\_ids                 | The VPC ID if the domain was created inside a VPC.                                                                         |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ CONFIG
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | access\_policies | IAM policy document specifying the access policies for the domain. | string | `""` | no |
+| az_count | Number of Availability Zones for the domain to use with zone_awareness_enabled. Valid values: 2 or 3. | number | 2 | no |
 | create\_iam\_service\_linked\_role | Control the creation of the default service role, set it to false if you have already created it. | bool | true | no |
 | dedicated\_master | Indicates whether our cluster have dedicated master nodes enabled. | string | `"false"` | no |
 | elasticsearch\_version | Elastic Search Service cluster version number. | string | `"5.5"` | no |

--- a/main.tf
+++ b/main.tf
@@ -62,12 +62,11 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_type    = var.mtype
     dedicated_master_count   = var.mcount
     zone_awareness_enabled   = var.zone_awareness
-
+    zone_awareness_config {
+      availability_zone_count = var.az_count
+    }
   }
 
-  zone_awareness_config {
-    availability_zone_count = var.az_count
-  }
 
   access_policies = var.access_policies
 

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,11 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_type    = var.mtype
     dedicated_master_count   = var.mcount
     zone_awareness_enabled   = var.zone_awareness
+
+  }
+
+  zone_awareness_config {
+    availability_zone_count = var.az_count
   }
 
   access_policies = var.access_policies

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_count   = var.mcount
     zone_awareness_enabled   = var.zone_awareness
     zone_awareness_config {
-      availability_zone_count = var.az_count
+       availability_zone_count = length(var.subnet_ids) > 2 ? 3 : 2
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,7 @@ variable "zone_awareness" {
 variable "az_count" {
   default     = 2
   description = "Number of Availability Zones for the domain to use with zone_awareness_enabled. Defaults to 2. Valid values: 2 or 3."
+  type        = number
 }
 
 variable "rest_action_multi_allow_explicit_index" {

--- a/variables.tf
+++ b/variables.tf
@@ -110,12 +110,6 @@ variable "zone_awareness" {
   type        = string
 }
 
-variable "az_count" {
-  default     = 2
-  description = "Number of Availability Zones for the domain to use with zone_awareness_enabled. Defaults to 2. Valid values: 2 or 3."
-  type        = number
-}
-
 variable "rest_action_multi_allow_explicit_index" {
   default     = "true"
   description = "Specifies whether explicit references to indices are allowed inside the body of HTTP requests."

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,11 @@ variable "zone_awareness" {
   type        = string
 }
 
+variable "az_count" {
+  default     = 2
+  description = "Number of Availability Zones for the domain to use with zone_awareness_enabled. Defaults to 2. Valid values: 2 or 3."
+}
+
 variable "rest_action_multi_allow_explicit_index" {
   default     = "true"
   description = "Specifies whether explicit references to indices are allowed inside the body of HTTP requests."


### PR DESCRIPTION
By default the availability_zone_count on the aws_elasticsearch_domain is 2. If you enable master and have 3 az's defined, this results in errors if your master count is less than the az count. 

This is really only relevant for people operating in 3 AZ's instead of 2 as it doesn't support higher counts above 3. 