### PR TITLE
Support up to 3 AZ's in multi-az support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ CONFIG
 }
 ```
 
+ Note On Multi-AZ Support:<br>
+ AWS Supports up to 3 AZ's for a multi-az configuration. Understand that if you operate in more than 3 AZ's and you choose to deploy master nodes, only 3 AZ's will be supported and any more than that may result in TF returning AWS API errors.<br> 
+ For more information see [here](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-dedicatedmasternodes.html)
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,9 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_type    = var.mtype
     dedicated_master_count   = var.mcount
     zone_awareness_enabled   = var.zone_awareness
+    zone_awareness_config {
+       availability_zone_count = length(var.subnet_ids) > 2 ? 3 : 2
+    }
   }
 
   access_policies = var.access_policies


### PR DESCRIPTION
By default the availability_zone_count on the aws_elasticsearch_domain is 2. Allow up to the max (3) AZ's and document in README the expectations around exceeding the AWS recommended count. 
